### PR TITLE
[Front/Back] Feat: 인증 프로세스 구현

### DIFF
--- a/sesac-docent-backend/src/main/java/com/fred/docent/config/WebConfig.java
+++ b/sesac-docent-backend/src/main/java/com/fred/docent/config/WebConfig.java
@@ -7,11 +7,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 @Configuration
 public class WebConfig extends WebMvcConfigurerAdapter {
 
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000")
-                .allowedMethods("*")
-                .allowedHeaders("*");
-    }
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry.addMapping("/**").allowedOrigins("http://localhost:3000").allowedMethods("*").allowedHeaders("*");
+	}
 }

--- a/sesac-docent-backend/src/main/java/com/fred/docent/domain/CustomUser.java
+++ b/sesac-docent-backend/src/main/java/com/fred/docent/domain/CustomUser.java
@@ -8,7 +8,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 
 public class CustomUser extends User {
-	
+
 	private UserDTO userDTO;
 
 	public CustomUser(String username, String password, Collection<? extends GrantedAuthority> authorities) {
@@ -16,10 +16,10 @@ public class CustomUser extends User {
 	}
 
 	public CustomUser(UserDTO userDTO) {
-		super(userDTO.getEmail(), userDTO.getPassword(), userDTO.getAuthorities()
-																	 .stream() // List ÇüÅÂ(getAuthorities())¸¦ ½ºÆ®¸²À¸·Î º¯È¯ÇØÁÖ´Â °úÁ¤
-																	 .map(auth -> new SimpleGrantedAuthority(auth.getAuth()))
-																	 .collect(Collectors.toList()));
+		super(userDTO.getEmail(), userDTO.getPassword(), userDTO.getAuthorities().stream() // List
+																							// ï¿½ï¿½ï¿½ï¿½(getAuthorities())ï¿½ï¿½
+																							// ï¿½ï¿½Æ®ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½È¯ï¿½ï¿½ï¿½Ö´ï¿½ ï¿½ï¿½ï¿½ï¿½
+				.map(auth -> new SimpleGrantedAuthority(auth.getAuth())).collect(Collectors.toList()));
 		this.userDTO = userDTO;
 	}
 

--- a/sesac-docent-backend/src/main/java/com/fred/docent/domain/LoginDTO.java
+++ b/sesac-docent-backend/src/main/java/com/fred/docent/domain/LoginDTO.java
@@ -8,5 +8,6 @@ import lombok.ToString;
 public class LoginDTO {
 	private String email;
 	private String password;
+	private String sessionId;
 
 }

--- a/sesac-docent-backend/src/main/java/com/fred/docent/domain/UserDTO.java
+++ b/sesac-docent-backend/src/main/java/com/fred/docent/domain/UserDTO.java
@@ -19,9 +19,9 @@ public class UserDTO {
 	private String username;
 	private Date createdat;
 	private String authority;
-	
+
 	private List<AuthDTO> authorities;
-	
-	private String authCode;  // ÀÎÁõ¹øÈ£¸¦ ÀúÀåÇÒ ÇÊµå
+
+	private String authCode; // ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½È£ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½Êµï¿½
 
 }

--- a/sesac-docent-backend/src/main/java/com/fred/docent/mapper/UserMapper.java
+++ b/sesac-docent-backend/src/main/java/com/fred/docent/mapper/UserMapper.java
@@ -18,9 +18,10 @@ public interface UserMapper {
 	public int dupId(String email);
 
 	public UserDTO readUserByEmail(String email); // email로 멤버 정보 가져오기
-	
+
 	public UserDTO checkUser(@Param("username") String username, @Param("email") String email);
-	
+
 	public UserDTO read(String email); // 회원 정보 읽어오기
 
+	public UserDTO readNameByEmail(String email);
 }

--- a/sesac-docent-backend/src/main/java/com/fred/docent/service/MailSendService.java
+++ b/sesac-docent-backend/src/main/java/com/fred/docent/service/MailSendService.java
@@ -8,27 +8,46 @@ import javax.mail.internet.MimeMessage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
+
+import com.fred.docent.domain.UserDTO;
 
 @Component
 @Service
 public class MailSendService {
 	private final JavaMailSender mailSender;
 	private Integer authNumber;
+	private Integer newPassword;
 
 	@Autowired
-	public MailSendService(JavaMailSender mailSender, Integer authNumber) {
+	private UserService service;
+
+	@Autowired
+	public BCryptPasswordEncoder encoder;
+
+	@Autowired
+	public MailSendService(JavaMailSender mailSender, Integer authNumber, Integer newPassword) {
 		this.mailSender = mailSender;
 		this.authNumber = authNumber;
+		this.newPassword = newPassword;
 	}
 
 	public void makeRandomNumber() {
-		// 난수의 범위 111111 ~ 999999 (6자리 난수)
+		// 난수의 범위 100000 ~ 999999 (6자리 난수)
 		Random r = new Random();
-		int checkNum = r.nextInt(888888) + 111111;
+		int checkNum = r.nextInt(900000) + 100000;
 		System.out.println("인증번호 : " + checkNum);
 		authNumber = checkNum;
+	}
+
+	public void makeRandomPassword() {
+		// 난수의 범위 100000000 ~ 999999999 (9자리 난수)
+		Random r = new Random();
+		int checkNum2 = r.nextInt(900000000) + 100000000;
+		System.out.println("인증번호 : " + checkNum2);
+		newPassword = checkNum2;
 	}
 
 	// 이메일 보내는 양식
@@ -41,6 +60,25 @@ public class MailSendService {
 				+ "해당 인증번호를 인증번호 확인란에 기입하여 주세요.";
 		mailSend(setFrom, toMail, title, content);
 		return Integer.toString(authNumber);
+	}
+
+	// 비밀번호 초기화 이메일
+	public String findPassword(String email) throws Exception {
+		makeRandomPassword();
+		String setFrom = "hsuyeon607@gmail.com";
+		String toMail = email;
+		String title = "새 비밀번호입니다.";
+		String content = "홈페이지를 방문해주셔서 감사합니다." + "<br><br>" + "새 비밀번호는 " + authNumber + "입니다." + "<br>"
+				+ "해당 비밀번호로 로그인해주세요.";
+		mailSend(setFrom, toMail, title, content);
+
+		String encryptedPassword = encoder.encode(Integer.toString(newPassword));
+		UserDTO userDTO = new UserDTO();
+		userDTO.setEmail(email);
+		userDTO.setPassword(encryptedPassword);
+		service.update(userDTO);
+
+		return Integer.toString(newPassword);
 	}
 
 	// �씠硫붿씪 �쟾�넚 硫붿냼�뱶

--- a/sesac-docent-backend/src/main/java/com/fred/docent/service/UserService.java
+++ b/sesac-docent-backend/src/main/java/com/fred/docent/service/UserService.java
@@ -1,15 +1,11 @@
 package com.fred.docent.service;
 
-import java.util.List;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Primary;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.fred.docent.domain.AuthDTO;
-import com.fred.docent.domain.LoginDTO;
 import com.fred.docent.domain.UserDTO;
 import com.fred.docent.mapper.UserMapper;
 
@@ -20,16 +16,16 @@ public class UserService {
 
 	private UserMapper mapper;
 	private BCryptPasswordEncoder encoder;
-	
+
 	@Autowired
 	public UserService(UserMapper mapper, BCryptPasswordEncoder encoder) {
-        this.mapper = mapper;
-        this.encoder = encoder;
-    }
+		this.mapper = mapper;
+		this.encoder = encoder;
+	}
 
 	public boolean insert(UserDTO userDTO) throws Exception {
 		userDTO.setPassword(encoder.encode(userDTO.getPassword()));
-		
+
 		boolean flag = mapper.insert(userDTO) == 1;
 		return flag;
 	}
@@ -49,10 +45,14 @@ public class UserService {
 	public UserDTO readUserByEmail(String email) {
 		return mapper.readUserByEmail(email);
 	};
-	
+
+	public UserDTO readNameByEmail(String email) {
+		return mapper.readNameByEmail(email);
+	};
+
 	public UserDTO checkUser(String username, String email) {
 		UserDTO user = mapper.checkUser(username, email);
-        return user;
-    }
+		return user;
+	}
 
 }

--- a/sesac-docent-backend/src/main/resources/com/fred/docent/mapper/UserMapper.xml
+++ b/sesac-docent-backend/src/main/resources/com/fred/docent/mapper/UserMapper.xml
@@ -22,7 +22,7 @@
 		<result property="userid" column="user_id"/>
 		<result property="username" column="user_name"/>
 		<result property="createdat" column="created_at"/>
-		<collection property="authorities" resultMap="authList"/>
+		<result property="authority" column="authority"/>
 	</resultMap>
 	
 	<select id="read" resultMap="userDTO">
@@ -53,5 +53,15 @@
 	    select * from users
     	where email = #{email} and user_name = #{username}
 	</select>
-
+	
+	<select id="readNameByEmail" resultType="UserDTO">
+   		select user_name AS userName from users
+   		where email = #{email}
+	</select>
+	
+<!-- 	<select id="readNameByEmail" resultType="UserDTO">
+   		select user\_name from users
+	    where email = #{email} ESCAPE '\'
+	</select>
+ -->
 </mapper>

--- a/sesac-docent-backend/src/main/webapp/WEB-INF/spring/security-context.xml
+++ b/sesac-docent-backend/src/main/webapp/WEB-INF/spring/security-context.xml
@@ -15,7 +15,7 @@
 					authentication-success-handler-ref="customLoginSuccessHandler"/>
 		<security:logout logout-success-url="/user/logout"/>
 		
-		<security:intercept-url pattern="/user/adminpage" access="hasRole('ROLE_ADMIN')"/>
+		<security:intercept-url pattern="/admin/*" access="hasRole('ROLE_ADMIN')"/>
 		<security:intercept-url pattern="/user/**" access="permitAll"/>
 		<security:csrf disabled="true"/>
 	</security:http>

--- a/sesac-docent-frontend/package-lock.json
+++ b/sesac-docent-frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@reduxjs/toolkit": "^2.0.1",
         "axios": "^1.6.2",
         "clsx": "^2.0.0",
+        "http-proxy-middleware": "^2.0.6",
         "lucide-react": "^0.294.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/sesac-docent-frontend/package.json
+++ b/sesac-docent-frontend/package.json
@@ -2,10 +2,12 @@
   "name": "sesac-docent-frontend",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:80",
   "dependencies": {
     "@reduxjs/toolkit": "^2.0.1",
     "axios": "^1.6.2",
     "clsx": "^2.0.0",
+    "http-proxy-middleware": "^2.0.6",
     "lucide-react": "^0.294.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/sesac-docent-frontend/src/App.js
+++ b/sesac-docent-frontend/src/App.js
@@ -14,8 +14,8 @@ import AdminGallery from "pages/admin/AdminGallery";
 import AdminArtist from "pages/admin/AdminArtist";
 import AdminInquiry from "pages/admin/AdminInquiry";
 import MyInfo from "pages/auth/MyInfo";
-import { Provider } from "react-redux";
 import { ReduxProvider } from "store/provider";
+import FindPassword from "pages/auth/FindPassword";
 
 const adminRoutes = [
   { name: "inquiry", component: <AdminInquiry /> },
@@ -36,6 +36,7 @@ const router = createBrowserRouter([
       { path: "login", element: <Login /> },
       { path: "register", element: <Register /> },
       { path: "myinfo", element: <MyInfo /> },
+      { path: "findPassword", element: <FindPassword /> },
     ],
   },
   {

--- a/sesac-docent-frontend/src/apis/api.js
+++ b/sesac-docent-frontend/src/apis/api.js
@@ -1,11 +1,11 @@
 import axios from "axios";
 
 const api = axios.create({
-  baseURL: process.env.SPRING_SERVER_URL || "http://localhost",
+  // baseURL: process.env.SPRING_SERVER_URL || "http://localhost",
   headers: {
     "Content-Type": "application/json",
     Accept: "application/json",
-    Authorization: localStorage.getItem("jwtToken"),
+    // Authorization: localStorage.getItem("jwtToken"),
   },
   withCredentials: true,
 });

--- a/sesac-docent-frontend/src/pages/auth/FindPassword.js
+++ b/sesac-docent-frontend/src/pages/auth/FindPassword.js
@@ -1,57 +1,38 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
 
-import {
-  validateEmail,
-  validatePassword,
-  validateConfirm,
-  validateNickname,
-} from "utils/validate-input";
+import { validateEmail, validateNickname } from "utils/validate-input";
 import { useInput } from "hooks/use-input";
 import api from "apis/api";
 
 import { SignError } from "pages/auth/components/SignError";
 import { SignInput } from "pages/auth/components/SignInput";
 import LoginImage from "assets/i_am_ground_wide.jpeg";
-import { useAppSelector } from "store/store";
+import { Link } from "react-router-dom";
 
-const MyInfo = () => {
-  const navigate = useNavigate();
+const FindPassword = () => {
   const email = useInput(validateEmail);
-  const oldPassword = useInput(validatePassword);
-  const newPassword = useInput(validatePassword);
-  const newConfirm = useInput((value) =>
-    validateConfirm(value, newPassword.value)
-  );
   const userName = useInput(validateNickname);
   const [hasError, setHasError] = useState(false);
+  const [success, setSuccess] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
-  const state = useAppSelector((state) => state.authReducer);
 
   const submitHandler = async (event) => {
     event.preventDefault();
-    const valid =
-      oldPassword.isValid && newPassword.isValid && newConfirm.isValid;
+    const valid = email.isValid && userName.isValid;
+
     if (!valid) {
       setHasError(valid);
-      setErrorMessage("비밀번호 형식이 올바르지 않습니다.");
+      setErrorMessage("입력 형식이 올바르지 않습니다.");
       return;
     }
 
-    const duplicated = oldPassword.value === newPassword.value;
-    if (duplicated) {
-      setHasError(duplicated);
-      setErrorMessage("바꾸려는 비밀번호가 기존 비밀번호와 같습니다.");
-      return;
-    }
-
-    const response = await api.post("/user/update", {
-      email: state.email,
-      oldPassword: oldPassword.value,
-      newPassword: newPassword.value,
+    const response = await api.post("/user/findPassword", {
+      email: email.value,
+      username: userName.value,
     });
-    if (response.data.message === "Success") {
-      navigate("/login");
+    if (response.status === 200) {
+      console.log("이메일로 받은 새 비밀번호: ", response.data.newPassword);
+      setSuccess(true);
     } else {
       setHasError(true);
       setErrorMessage(response.data.message);
@@ -62,49 +43,40 @@ const MyInfo = () => {
     <div className="flex justify-center mt-24 mb-16">
       <div className="max-w-[1300px] flex justify-between">
         <div className="w-fit py-16 flex flex-col justify-center gap-8 mx-10">
-          <p className="w-fit text-7xl font-bold">마이페이지</p>
+          <p className="w-fit text-7xl font-bold">비밀번호 찾기</p>
           <form className="flex flex-col gap-4 w-fit sm:w-[350px] md:w-[400px] lg:w-[450px] xl:w-[500px] 2xl:w-[560px] border border-black p-4">
             <SignInput
               type="email"
               label="이메일 *"
               inputState={email}
               errorMessage="이메일 형식이 올바르지 않습니다."
-              placeholder={state.email}
-              readOnly={true}
-            />
-            <SignInput
-              type="password"
-              label="기존 비밀번호 *"
-              inputState={oldPassword}
-              errorMessage="8~16자의 영문 대/소문자, 숫자, 특수문자를 사용해 주세요."
-            />
-            <SignInput
-              type="password"
-              label="새 비밀번호 *"
-              inputState={newPassword}
-              errorMessage="8~16자의 영문 대/소문자, 숫자, 특수문자를 사용해 주세요."
-            />
-            <SignInput
-              type="password"
-              label="새 비밀번호 확인 *"
-              inputState={newConfirm}
-              errorMessage="비밀번호가 일치하지 않습니다."
             />
             <SignInput
               type="text"
               label="이름 *"
               inputState={userName}
               errorMessage="2~16자의 한글을 올바르게 입력해 주세요."
-              placeholder={state.name}
-              readOnly={true}
             />
             {hasError && <SignError message={errorMessage} />}
+            {success && (
+              <p className="text-lg font-medium text-teal-500">
+                새 비밀번호가 메일로 전송되었습니다.
+              </p>
+            )}
             <div className="flex gap-4 justify-end">
+              {success && (
+                <Link
+                  to="/login"
+                  className="w-fit h-fit px-4 py-2 border border-black text-lg font-bold hover:bg-black hover:text-white transition"
+                >
+                  로그인
+                </Link>
+              )}
               <button
                 onClick={submitHandler}
                 className="w-fit h-fit px-4 py-2 border border-black text-lg font-bold hover:bg-black hover:text-white transition"
               >
-                수정
+                비밀번호 찾기
               </button>
             </div>
           </form>
@@ -123,4 +95,4 @@ const MyInfo = () => {
   );
 };
 
-export default MyInfo;
+export default FindPassword;

--- a/sesac-docent-frontend/src/pages/auth/Login.js
+++ b/sesac-docent-frontend/src/pages/auth/Login.js
@@ -27,16 +27,20 @@ const Login = () => {
       return;
     }
 
-    dispatch(login({ email: email.value }));
-    navigate("/");
-
-    // const response = await api.post("/auth/login", { email, password });
-    // if (!response?.error) {
-    //   navigate.push("/");
-    // } else {
-    //   console.log("Login Failed.");
-    //   setIsValid(false);
-    // }
+    const response = await api.post("/user/login", {
+      email: email.value,
+      password: password.value,
+    });
+    const name = response.data.username;
+    const authority = response.data.authority;
+    console.log({ email: email.value, name, role: authority });
+    dispatch(login({ email: email.value, name, role: authority }));
+    if (!response?.error) {
+      navigate("/");
+    } else {
+      console.log("Login Failed.");
+      setIsValid(false);
+    }
   };
 
   return (

--- a/sesac-docent-frontend/src/pages/auth/Login.js
+++ b/sesac-docent-frontend/src/pages/auth/Login.js
@@ -31,10 +31,8 @@ const Login = () => {
       email: email.value,
       password: password.value,
     });
-    const name = response.data.username;
-    const authority = response.data.authority;
-    console.log({ email: email.value, name, role: authority });
-    dispatch(login({ email: email.value, name, role: authority }));
+    const { username: name, authority: role } = response.data;
+    dispatch(login({ email: email.value, name, role }));
     if (!response?.error) {
       navigate("/");
     } else {
@@ -70,23 +68,20 @@ const Login = () => {
               <SignError message="아이디 또는 비밀번호를 다시 입력해주세요." />
             )}
             <div className="mt-3 w-full flex gap-4">
-              <Link to="#" className="hover:underline">
-                아이디 찾기
-              </Link>
-              <Link to="#" className="hover:underline">
+              <Link to="/findPassword" className="hover:underline">
                 비밀번호 찾기
               </Link>
             </div>
             <div className="flex gap-4">
               <button
                 onClick={submitHandler}
-                className="w-fit h-fit px-4 py-2 border border-black text-lg font-bold"
+                className="w-fit h-fit px-4 py-2 border border-black text-lg font-bold hover:bg-black hover:text-white transition"
               >
                 로그인
               </button>
               <Link
                 to="/register"
-                className="w-fit h-fit px-4 py-2 border border-black text-lg font-bold"
+                className="w-fit h-fit px-4 py-2 border border-black text-lg font-bold hover:bg-black hover:text-white transition"
               >
                 회원가입
               </Link>

--- a/sesac-docent-frontend/src/pages/auth/MyInfo.js
+++ b/sesac-docent-frontend/src/pages/auth/MyInfo.js
@@ -62,7 +62,7 @@ const MyInfo = () => {
     <div className="flex justify-center mt-24 mb-16">
       <div className="max-w-[1300px] flex justify-between">
         <div className="w-fit py-16 flex flex-col justify-center gap-8 mx-10">
-          <p className="w-fit text-7xl font-bold">마이페이지</p>
+          <p className="w-fit text-7xl font-bold">회원정보 수정</p>
           <form className="flex flex-col gap-4 w-fit sm:w-[350px] md:w-[400px] lg:w-[450px] xl:w-[500px] 2xl:w-[560px] border border-black p-4">
             <SignInput
               type="email"

--- a/sesac-docent-frontend/src/pages/auth/Register.js
+++ b/sesac-docent-frontend/src/pages/auth/Register.js
@@ -24,8 +24,6 @@ const Register = () => {
   const confirm = useInput((value) => validateConfirm(value, password.value));
   const userName = useInput(validateNickname);
   const [isValid, setIsValid] = useState(true);
-  const [isDuplicated, setIsDuplicated] = useState(false);
-  const [errorMessage, setErrorMessage] = useState("");
   const [emailUnique, setEmailUnique] = useState(false);
   const [serverAuthNumber, setServerAuthNumber] = useState("");
   const [authNumberValid, setAuthNumberValid] = useState(false);
@@ -35,7 +33,6 @@ const Register = () => {
     const valid =
       email.isValid && password.isValid && confirm.isValid && userName.isValid;
     setIsValid(valid);
-    setIsDuplicated(false);
 
     if (!valid) {
       return;
@@ -98,11 +95,10 @@ const Register = () => {
               errorMessage="2~16자의 한글을 올바르게 입력해 주세요."
             />
             {!isValid && <SignError message="입력값을 다시 확인해주세요." />}
-            {isDuplicated && <SignError message={errorMessage} />}
             <div className="flex gap-4 justify-end">
               <button
                 onClick={submitHandler}
-                className="w-fit h-fit px-4 py-2 border border-black text-lg font-bold"
+                className="w-fit h-fit px-4 py-2 border border-black text-lg font-bold hover:bg-black hover:text-white transition"
               >
                 회원가입
               </button>

--- a/sesac-docent-frontend/src/pages/auth/Register.js
+++ b/sesac-docent-frontend/src/pages/auth/Register.js
@@ -6,6 +6,7 @@ import {
   validatePassword,
   validateConfirm,
   validateNickname,
+  validateAuthNumber,
 } from "utils/validate-input";
 import { useInput } from "hooks/use-input";
 import api from "apis/api";
@@ -18,7 +19,7 @@ import { SignInputCheck } from "./components/SignInputCheck";
 const Register = () => {
   const navigate = useNavigate();
   const email = useInput(validateEmail);
-  const authNumber = useInput(validateEmail);
+  const authNumber = useInput(validateAuthNumber);
   const password = useInput(validatePassword);
   const confirm = useInput((value) => validateConfirm(value, password.value));
   const userName = useInput(validateNickname);
@@ -26,6 +27,7 @@ const Register = () => {
   const [isDuplicated, setIsDuplicated] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
   const [emailUnique, setEmailUnique] = useState(false);
+  const [serverAuthNumber, setServerAuthNumber] = useState("");
   const [authNumberValid, setAuthNumberValid] = useState(false);
 
   const submitHandler = async (event) => {
@@ -39,22 +41,13 @@ const Register = () => {
       return;
     }
 
-    const response = await api.post("/auth/register", {
-      email,
-      password,
-      userName,
+    await api.post("/user/insert", {
+      email: email.value,
+      password: password.value,
+      username: userName.value,
     });
-    if (response.data.message === "success") {
-      navigate.push("/login");
-    } else {
-      if (response.data.errorCode === "email")
-        setErrorMessage("이미 존재하는 이메일입니다.");
-      if (response.data.errorCode === "name")
-        setErrorMessage("이미 존재하는 이름입니다.");
-      setIsDuplicated(true);
-      setIsValid(false);
-    }
-    console.log(response.data.message);
+
+    navigate("/login");
   };
 
   return (
@@ -71,6 +64,7 @@ const Register = () => {
               inputState={email}
               errorMessage="이메일 형식이 올바르지 않습니다."
               setEmailUnique={setEmailUnique}
+              setServerAuthNumber={setServerAuthNumber}
             />
             {emailUnique && (
               <SignInputCheck
@@ -80,7 +74,9 @@ const Register = () => {
                 label="인증번호 *"
                 inputState={authNumber}
                 errorMessage="인증번호 형식이 올바르지 않습니다."
+                serverAuthNumber={serverAuthNumber}
                 setAuthNumberValid={setAuthNumberValid}
+                authNumberValid={authNumberValid}
               />
             )}
             <SignInput

--- a/sesac-docent-frontend/src/pages/auth/Register.js
+++ b/sesac-docent-frontend/src/pages/auth/Register.js
@@ -66,6 +66,7 @@ const Register = () => {
             <SignInputCheck
               type="email"
               checkType="emailUnique"
+              value={email.value}
               label="이메일 *"
               inputState={email}
               errorMessage="이메일 형식이 올바르지 않습니다."
@@ -73,8 +74,9 @@ const Register = () => {
             />
             {emailUnique && (
               <SignInputCheck
-                type="number"
+                type="authNumber"
                 checkType="authNumber"
+                value={authNumber.value}
                 label="인증번호 *"
                 inputState={authNumber}
                 errorMessage="인증번호 형식이 올바르지 않습니다."

--- a/sesac-docent-frontend/src/pages/auth/components/SignInputCheck.js
+++ b/sesac-docent-frontend/src/pages/auth/components/SignInputCheck.js
@@ -1,16 +1,41 @@
 import api from "apis/api";
+import axios from "axios";
 import { X } from "lucide-react";
+import { useState } from "react";
+import { validateEmail } from "utils/validate-input";
 
 export const SignInputCheck = (props) => {
+  const [unique, setUnique] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
   const isValid = props.inputState?.hasError ? "invalid" : "normal";
   const colorVariants = {
     normal: "flex items-center gap-1 text-2xl font-semibold text-black",
     invalid: "flex items-center gap-1 text-2xl font-semibold text-rose-700",
   };
 
-  const checkHandler = (event) => {
+  const checkHandler = async (event) => {
     event.preventDefault();
-    props.setEmailUnique(true);
+
+    if (!validateEmail(props.value)) {
+      return;
+    }
+
+    if (props.checkType === "emailUnique") {
+      const response = await axios.get(`/user/${props.value}`);
+      const isUnique = response.data.isUnique;
+
+      if (isUnique) {
+        setUnique(true);
+        setSubmitted(true);
+        props.setEmailUnique(true);
+        console.log("This email is unique.");
+      } else {
+        setUnique(false);
+        setSubmitted(true);
+        props.setEmailUnique(false);
+        console.log("This email is duplicated.");
+      }
+    }
   };
 
   return (
@@ -40,6 +65,16 @@ export const SignInputCheck = (props) => {
       {isValid === "invalid" && (
         <p className="text-lg font-medium text-rose-700">
           {props.errorMessage}
+        </p>
+      )}
+      {props.checkType === "emailUnique" && unique && submitted && (
+        <p className="text-lg font-medium text-teal-500">
+          사용할 수 있는 이메일입니다.
+        </p>
+      )}
+      {props.checkType === "emailUnique" && !unique && submitted && (
+        <p className="text-lg font-medium text-rose-500">
+          이미 가입된 이메일입니다.
         </p>
       )}
     </div>

--- a/sesac-docent-frontend/src/pages/auth/components/SignInputCheck.js
+++ b/sesac-docent-frontend/src/pages/auth/components/SignInputCheck.js
@@ -1,5 +1,4 @@
 import api from "apis/api";
-import axios from "axios";
 import { X } from "lucide-react";
 import { useState } from "react";
 import { validateEmail } from "utils/validate-input";
@@ -7,7 +6,6 @@ import { validateEmail } from "utils/validate-input";
 export const SignInputCheck = (props) => {
   const [unique, setUnique] = useState(false);
   const [submitted, setSubmitted] = useState(false);
-  const [myAuthNumber, setMyAuthNumber] = useState("");
   const isValid = props.inputState?.hasError ? "invalid" : "normal";
   const colorVariants = {
     normal: "flex items-center gap-1 text-2xl font-semibold text-black",
@@ -21,12 +19,7 @@ export const SignInputCheck = (props) => {
       if (!validateEmail(props.value)) {
         return;
       }
-      const response = await axios.get(`/user/${props.value}`, {
-        headers: {
-          "Content-Type": "application/json",
-          Accept: "application/json",
-        },
-      });
+      const response = await api.get(`/user/${props.value}`);
       const isUnique = response.data.isUnique;
 
       if (isUnique) {

--- a/sesac-docent-frontend/src/pages/auth/components/SignInputCheck.js
+++ b/sesac-docent-frontend/src/pages/auth/components/SignInputCheck.js
@@ -7,6 +7,7 @@ import { validateEmail } from "utils/validate-input";
 export const SignInputCheck = (props) => {
   const [unique, setUnique] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const [myAuthNumber, setMyAuthNumber] = useState("");
   const isValid = props.inputState?.hasError ? "invalid" : "normal";
   const colorVariants = {
     normal: "flex items-center gap-1 text-2xl font-semibold text-black",
@@ -16,18 +17,24 @@ export const SignInputCheck = (props) => {
   const checkHandler = async (event) => {
     event.preventDefault();
 
-    if (!validateEmail(props.value)) {
-      return;
-    }
-
     if (props.checkType === "emailUnique") {
-      const response = await axios.get(`/user/${props.value}`);
+      if (!validateEmail(props.value)) {
+        return;
+      }
+      const response = await axios.get(`/user/${props.value}`, {
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+      });
       const isUnique = response.data.isUnique;
 
       if (isUnique) {
         setUnique(true);
         setSubmitted(true);
         props.setEmailUnique(true);
+        props.setServerAuthNumber(response.data.authNumber);
+        console.log("서버로부터 받은 인증 번호: ", response.data.authNumber);
         console.log("This email is unique.");
       } else {
         setUnique(false);
@@ -35,6 +42,14 @@ export const SignInputCheck = (props) => {
         props.setEmailUnique(false);
         console.log("This email is duplicated.");
       }
+    }
+
+    if (props.checkType === "authNumber") {
+      setSubmitted(true);
+      console.log("입력한 인증번호: ", props.value);
+      props.setAuthNumberValid(
+        props.value === props.serverAuthNumber ? true : false
+      );
     }
   };
 
@@ -77,6 +92,20 @@ export const SignInputCheck = (props) => {
           이미 가입된 이메일입니다.
         </p>
       )}
+      {props.checkType === "authNumber" &&
+        props.authNumberValid &&
+        submitted && (
+          <p className="text-lg font-medium text-teal-500">
+            인증이 완료되었습니다.
+          </p>
+        )}
+      {props.checkType === "authNumber" &&
+        !props.authNumberValid &&
+        submitted && (
+          <p className="text-lg font-medium text-rose-500">
+            인증 번호가 일치하지 않습니다.
+          </p>
+        )}
     </div>
   );
 };

--- a/sesac-docent-frontend/src/pages/home/Home.js
+++ b/sesac-docent-frontend/src/pages/home/Home.js
@@ -1,12 +1,8 @@
 import HomeImage from "assets/home_fred_tokyo.jpeg";
 
 import { HomeCardBox } from "./components/HomeCardBox";
-import { useAppSelector } from "store/store";
 
 const Home = () => {
-  const state = useAppSelector((state) => state.authReducer);
-  console.log(state.email, state.name, state.role);
-
   return (
     <div className="w-full">
       <div className="w-full h-fit aspect-video">

--- a/sesac-docent-frontend/src/pages/home/Home.js
+++ b/sesac-docent-frontend/src/pages/home/Home.js
@@ -5,7 +5,7 @@ import { useAppSelector } from "store/store";
 
 const Home = () => {
   const state = useAppSelector((state) => state.authReducer);
-  console.log(state.email);
+  console.log(state.email, state.name, state.role);
 
   return (
     <div className="w-full">

--- a/sesac-docent-frontend/src/pages/layout/AdminLayout.js
+++ b/sesac-docent-frontend/src/pages/layout/AdminLayout.js
@@ -1,13 +1,47 @@
-import { createContext, useState } from "react";
+import { createContext, useEffect, useState } from "react";
 import { Outlet } from "react-router-dom";
 
 import { AdminHeader } from "pages/layout/components/AdminHeader";
 import { AdminSidebar } from "pages/layout/components/AdminSidebar";
 import { cn } from "utils/tailwind-merge";
+import { useDispatch } from "react-redux";
+import { useAppSelector } from "store/store";
+import { login } from "store/features/auth-slice";
+import api from "apis/api";
 
 export const MenuContext = createContext();
 
 const AdminLayout = () => {
+  const dispatch = useDispatch();
+  const state = useAppSelector((state) => state.authReducer);
+
+  const hasValidSessionId = () => {
+    const sessionId = document.cookie
+      .split("; ")
+      .find((row) => row.startsWith("JSESSIONID"))
+      ?.split("=")[1];
+
+    return !!sessionId && sessionId.length > 10;
+  };
+
+  useEffect(() => {
+    if (state.email || !hasValidSessionId()) {
+      return;
+    }
+
+    const fetchLoginInfo = async () => {
+      try {
+        const response = await api.get("/user/loginBySessionId");
+        const { email, username: name, authority: role } = response.data;
+        dispatch(login({ email, name, role }));
+      } catch (error) {
+        console.error("Error fetching login info:", error);
+      }
+    };
+
+    fetchLoginInfo();
+  }, [dispatch, state.email]);
+
   const [menuClicked, setMenuClicked] = useState(false);
 
   const menuClickHandler = () => {

--- a/sesac-docent-frontend/src/pages/layout/RootLayout.js
+++ b/sesac-docent-frontend/src/pages/layout/RootLayout.js
@@ -2,8 +2,43 @@ import { Outlet } from "react-router-dom";
 
 import { Header } from "pages/layout/components/Header";
 import { Footer } from "pages/layout/components/Footer";
+import { useEffect } from "react";
+import api from "apis/api";
+import { useDispatch } from "react-redux";
+import { login } from "store/features/auth-slice";
+import { useAppSelector } from "store/store";
 
 const RootLayout = () => {
+  const dispatch = useDispatch();
+  const state = useAppSelector((state) => state.authReducer);
+
+  const hasValidSessionId = () => {
+    const sessionId = document.cookie
+      .split("; ")
+      .find((row) => row.startsWith("JSESSIONID"))
+      ?.split("=")[1];
+
+    return !!sessionId && sessionId.length > 10;
+  };
+
+  useEffect(() => {
+    if (state.email || !hasValidSessionId()) {
+      return;
+    }
+
+    const fetchLoginInfo = async () => {
+      try {
+        const response = await api.get("/user/loginBySessionId");
+        const { email, username: name, authority: role } = response.data;
+        dispatch(login({ email, name, role }));
+      } catch (error) {
+        console.error("Error fetching login info:", error);
+      }
+    };
+
+    fetchLoginInfo();
+  }, [dispatch, state.email]);
+
   return (
     <>
       <div className="w-full h-full bg-white">

--- a/sesac-docent-frontend/src/pages/layout/components/AdminHeader.js
+++ b/sesac-docent-frontend/src/pages/layout/components/AdminHeader.js
@@ -34,7 +34,7 @@ export const AdminHeader = () => {
       </div>
       <div className="w-1/3 flex justify-end items-center gap-4 text-zinc-800">
         {true && <UpperHeaderLink link="/" text="고객페이지" />}
-        {true && <UpperHeaderLink link="/logout" text="로그아웃" />}
+        {true && <UpperHeaderLink link="/" text="로그아웃" />}
       </div>
     </div>
   );

--- a/sesac-docent-frontend/src/pages/layout/components/Header.js
+++ b/sesac-docent-frontend/src/pages/layout/components/Header.js
@@ -34,7 +34,9 @@ export const Header = () => {
           {state.role === "ROLE_ADMIN" && (
             <UpperHeaderLink link="/admin" text="관리자" />
           )}
-          {state.email && <UpperHeaderLink link="/myinfo" text="마이페이지" />}
+          {state.email && (
+            <UpperHeaderLink link="/myinfo" text="회원정보 수정" />
+          )}
           {state.email && <UpperHeaderLink link="/" text="로그아웃" />}
           {!state.email && <UpperHeaderLink link="/register" text="회원가입" />}
           {!state.email && <UpperHeaderLink link="/login" text="로그인" />}

--- a/sesac-docent-frontend/src/pages/layout/components/Header.js
+++ b/sesac-docent-frontend/src/pages/layout/components/Header.js
@@ -5,10 +5,12 @@ import { LinkBox, LowerHeaderLink, UpperHeaderLink } from "./LayoutLinks";
 import LogoSvg from "assets/logo_horizontal.svg";
 
 import { cn } from "utils/tailwind-merge";
+import { useAppSelector } from "store/store";
 
 export const Header = () => {
   const [height, setHeight] = useState(95);
   const [navFixed, setNavFixed] = useState(false);
+  const state = useAppSelector((state) => state.authReducer);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -29,11 +31,13 @@ export const Header = () => {
     <div className="w-full flex flex-col items-center justify-center bg-white">
       <div className="w-full h-[36px] bg-zinc-200 flex justify-center ">
         <div className="w-full max-w-[1300px] flex justify-end items-center gap-4">
-          {true && <UpperHeaderLink link="/admin" text="관리자" />}
-          {true && <UpperHeaderLink link="/myinfo" text="마이페이지" />}
-          {true && <UpperHeaderLink link="/logout" text="로그아웃" />}
-          {true && <UpperHeaderLink link="/register" text="회원가입" />}
-          {true && <UpperHeaderLink link="/login" text="로그인" />}
+          {state.role === "ROLE_ADMIN" && (
+            <UpperHeaderLink link="/admin" text="관리자" />
+          )}
+          {state.email && <UpperHeaderLink link="/myinfo" text="마이페이지" />}
+          {state.email && <UpperHeaderLink link="/" text="로그아웃" />}
+          {!state.email && <UpperHeaderLink link="/register" text="회원가입" />}
+          {!state.email && <UpperHeaderLink link="/login" text="로그인" />}
         </div>
       </div>
       <div

--- a/sesac-docent-frontend/src/pages/layout/components/LayoutLinks.js
+++ b/sesac-docent-frontend/src/pages/layout/components/LayoutLinks.js
@@ -5,12 +5,25 @@ import { IoMdPlay } from "react-icons/io";
 import { MenuContext } from "pages/layout/AdminLayout";
 
 import { cn } from "utils/tailwind-merge";
+import { useDispatch } from "react-redux";
+import { logout } from "store/features/auth-slice";
 
 export const UpperHeaderLink = ({ link, text }) => {
+  const dispatch = useDispatch();
+
+  const logoutHandler = () => {
+    if (text !== "로그아웃") {
+      return;
+    }
+    console.log(1);
+    dispatch(logout());
+  };
+
   return (
     <Link
       to={`${link}`}
       className="flex justify-center items-center gap-1 w-fit font-semibold"
+      onClick={logoutHandler}
     >
       <IoMdPlay size={12} />
       {text}

--- a/sesac-docent-frontend/src/pages/layout/components/LayoutLinks.js
+++ b/sesac-docent-frontend/src/pages/layout/components/LayoutLinks.js
@@ -7,16 +7,25 @@ import { MenuContext } from "pages/layout/AdminLayout";
 import { cn } from "utils/tailwind-merge";
 import { useDispatch } from "react-redux";
 import { logout } from "store/features/auth-slice";
+import api from "apis/api";
 
 export const UpperHeaderLink = ({ link, text }) => {
   const dispatch = useDispatch();
 
-  const logoutHandler = () => {
+  const logoutHandler = async () => {
     if (text !== "로그아웃") {
       return;
     }
-    console.log(1);
-    dispatch(logout());
+
+    const response = await api.get("/user/logout");
+    if (response.data.message === "Logout Success") {
+      console.log(response.data.message);
+      document.cookie =
+        "JSESSIONID=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
+      dispatch(logout());
+    } else {
+      console.log(response.data.message);
+    }
   };
 
   return (

--- a/sesac-docent-frontend/src/setupProxy.js
+++ b/sesac-docent-frontend/src/setupProxy.js
@@ -1,0 +1,14 @@
+const { createProxyMiddleware } = require("http-proxy-middleware");
+
+module.exports = function (app) {
+  app.use(
+    "/api",
+    createProxyMiddleware({
+      target: "http://localhost:80",
+      changeOrigin: true,
+      pathRewrite: {
+        "^/api": "",
+      },
+    })
+  );
+};


### PR DESCRIPTION
## Key Changes

1. 회원가입 (이메일 인증)
    - 이메일 입력 및 유효성 검사 이후, 난수 6자리 숫자 문자열을 메일로 전송함.
    - 이메일로 받은 난수와 클라이언트가 입력한 난수가 같은지 비교하여 이메일 인증 수행.

2. 로그인
    - 이메일과 비밀번호를 서버의 "/user/login"으로 Post Request를 보내서 인증을 수행함.
    - 서버는 인증을 완료하고 session id를 쿠키에 담아서 리턴함.

3. 새로고침 시 자동 인증
    - React는 새로고침하면 모든 state가 초기화되기 때문에 새로고침 시 재인증이 필요함.
    - state.email을 확인하여 인증 정보가 없고, document.cookie를 확인하여 유효한 세션 쿠키가 있을 때 서버의 "/user/loginBySessionId"로 Get Request를 보내서 인증을 수행함.
    - 정상적으로 반환되었다면 반환된 계정 정보를 다시 redux에 저장함.

4. 로그아웃
    - 서버의 "/user/logout"으로 Get Request를 보내서"session.invalidate()"를 통해 세션을 무효화함.
    - 로그아웃이 정상적으로 완료되었다면 클라이언트에서도 쿠키를 만료시킴으로써 로그아웃을 수행함.

3. 회원정보 수정(비밀번호 수정)
4. 비밀번호 찾기

## Notes

1. Secure Cookie는 설정했지만 개발 상의 편의를 위해 HTTPS Only 옵션은 설정하지 않았음.